### PR TITLE
Remove lost beacons

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -123,7 +123,7 @@
 			{
 				// Only show beacons updated during the last 60 seconds.
 				var beacon = beacons[key];
-				if (beacon.timeStamp - 60000 > timeNow)
+				if (beacon.timeStamp + 60000 < timeNow)
 				{
 					delete beacons[key];
 				}


### PR DESCRIPTION
Changed logic to remove beacon if the beacons timestamp is older than 60 seconds.
Before it was asking if the beacons timestamp was more than the current time to remove.
